### PR TITLE
update(1.21.8): 更新至1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'idea'
-    id 'net.neoforged.moddev' version '2.0.78'
+    id 'net.neoforged.moddev' version '2.0.107'
 }
 
 version = mod_version
@@ -50,8 +50,12 @@ neoForge {
             programArguments.addAll '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
         }
 
+        var isJbr = System.getProperty('java.vm.vendor').contains('JetBrains')
         configureEach {
             systemProperty 'forge.logging.markers', 'REGISTRIES'
+            if (isJbr) {
+                jvmArgument "-XX:+AllowEnhancedClassRedefinition"
+            }
             logLevel = org.slf4j.event.Level.DEBUG
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 # Dev Info
-minecraft_version=1.21.4
-minecraft_version_range=[1.21.4,1.22)
-neo_version=21.4.119-beta
+minecraft_version=1.21.8
+minecraft_version_range=[1.21.8,1.22)
+neo_version=21.8.40
 neo_version_range=[21,)
 loader_version_range=[4,)
-parchment_minecraft_version=1.21.4
-parchment_mappings_version=2025.03.16
+parchment_minecraft_version=1.21.8
+parchment_mappings_version=2025.07.20
 # Mod Info
 mod_id=kaleidoscope_doll
 mod_name=Kaleidoscope Doll

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/block/DollGiftBoxBlock.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/block/DollGiftBoxBlock.java
@@ -10,9 +10,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -27,9 +24,9 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
+import java.util.function.Consumer;
 
-public class DollGiftBoxBlock extends HorizontalDirectionalBlock {
+public class DollGiftBoxBlock extends HorizontalDirectionalBlock implements IModBlock {
     private static final MapCodec<DollGiftBoxBlock> CODEC = simpleCodec(DollGiftBoxBlock::new);
     private static final VoxelShape SHAPE = Block.box(1.0d, 0.0d, 1.0d, 15.0d, 15.0d, 15.0d);
 
@@ -69,12 +66,12 @@ public class DollGiftBoxBlock extends HorizontalDirectionalBlock {
     }
 
     @Override
-    public void appendHoverText(ItemStack pStack, Item.TooltipContext context, List<Component> tooltip, TooltipFlag pFlag) {
-        tooltip.add(Component.translatable("tooltip.kaleidoscope_doll.doll_gift_box").withStyle(ChatFormatting.DARK_GRAY));
+    protected MapCodec<? extends HorizontalDirectionalBlock> codec() {
+        return CODEC;
     }
 
     @Override
-    protected MapCodec<? extends HorizontalDirectionalBlock> codec() {
-        return CODEC;
+    public void appendHoverText(Consumer<Component> tooltipAdder) {
+        tooltipAdder.accept(Component.translatable("tooltip.kaleidoscope_doll.doll_gift_box").withStyle(ChatFormatting.DARK_GRAY));
     }
 }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/block/DollMachineBlock.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/block/DollMachineBlock.java
@@ -23,7 +23,6 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -39,9 +38,9 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
-import java.util.List;
+import java.util.function.Consumer;
 
-public class DollMachineBlock extends HorizontalDirectionalBlock {
+public class DollMachineBlock extends HorizontalDirectionalBlock implements IModBlock {
     private static final MapCodec<DollMachineBlock> CODEC = simpleCodec(DollMachineBlock::new);
     private static final VoxelShape SHAPE_UPPER = Block.box(1.0d, 0.0d, 1.0d, 15.0d, 8.0d, 15.0d);
     private static final VoxelShape SHAPE = Block.box(1.0d, 0.0d, 1.0d, 15.0d, 16.0d, 15.0d);
@@ -183,12 +182,12 @@ public class DollMachineBlock extends HorizontalDirectionalBlock {
     }
 
     @Override
-    public void appendHoverText(ItemStack pStack, Item.TooltipContext context, List<Component> tooltip, TooltipFlag pFlag) {
-        tooltip.add(Component.translatable("tooltip.kaleidoscope_doll.doll_machine").withStyle(ChatFormatting.DARK_GRAY));
+    protected MapCodec<? extends HorizontalDirectionalBlock> codec() {
+        return CODEC;
     }
 
     @Override
-    protected MapCodec<? extends HorizontalDirectionalBlock> codec() {
-        return CODEC;
+    public void appendHoverText(Consumer<Component> tooltipAdder) {
+        tooltipAdder.accept(Component.translatable("tooltip.kaleidoscope_doll.doll_machine").withStyle(ChatFormatting.DARK_GRAY));
     }
 }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/block/IModBlock.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/block/IModBlock.java
@@ -1,0 +1,9 @@
+package com.github.ysbbbbbb.kaleidoscopedoll.block;
+
+import net.minecraft.network.chat.Component;
+
+import java.util.function.Consumer;
+
+public interface IModBlock {
+    void appendHoverText(Consumer<Component> tooltipAdder);
+}

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/config/package-info.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/config/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.github.ysbbbbbb.kaleidoscopedoll.config;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/event/ModRegisterEvent.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/event/ModRegisterEvent.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-@EventBusSubscriber(modid = KaleidoscopeDoll.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = KaleidoscopeDoll.MOD_ID)
 public class ModRegisterEvent {
     public static final Map<ResourceLocation, DollBlock> DOLL_BLOCKS = Maps.newHashMap();
     public static final Map<ResourceLocation, String> SPECIAL_TOOLTIPS = Maps.newHashMap();

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/event/package-info.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/event/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.github.ysbbbbbb.kaleidoscopedoll.event;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/init/ModBlocks.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/init/ModBlocks.java
@@ -1,18 +1,16 @@
 package com.github.ysbbbbbb.kaleidoscopedoll.init;
 
 import com.github.ysbbbbbb.kaleidoscopedoll.KaleidoscopeDoll;
-import com.github.ysbbbbbb.kaleidoscopedoll.block.DollBlock;
 import com.github.ysbbbbbb.kaleidoscopedoll.block.DollGiftBoxBlock;
 import com.github.ysbbbbbb.kaleidoscopedoll.block.DollMachineBlock;
-import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public class ModBlocks {
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(KaleidoscopeDoll.MOD_ID);
 
-    public static DeferredBlock<Block> DOLL_MACHINE = BLOCKS.registerBlock("doll_machine", DollMachineBlock::new);
-    public static DeferredBlock<Block> PURPLE_DOLL_GIFT_BOX = BLOCKS.registerBlock("purple_doll_gift_box", DollGiftBoxBlock::new);
-    public static DeferredBlock<Block> GREEN_DOLL_GIFT_BOX = BLOCKS.registerBlock("green_doll_gift_box", DollGiftBoxBlock::new);
-    public static DeferredBlock<Block> YELLOW_DOLL_GIFT_BOX = BLOCKS.registerBlock("yellow_doll_gift_box", DollGiftBoxBlock::new);
+    public static DeferredBlock<DollMachineBlock> DOLL_MACHINE = BLOCKS.registerBlock("doll_machine", DollMachineBlock::new);
+    public static DeferredBlock<DollGiftBoxBlock> PURPLE_DOLL_GIFT_BOX = BLOCKS.registerBlock("purple_doll_gift_box", DollGiftBoxBlock::new);
+    public static DeferredBlock<DollGiftBoxBlock> GREEN_DOLL_GIFT_BOX = BLOCKS.registerBlock("green_doll_gift_box", DollGiftBoxBlock::new);
+    public static DeferredBlock<DollGiftBoxBlock> YELLOW_DOLL_GIFT_BOX = BLOCKS.registerBlock("yellow_doll_gift_box", DollGiftBoxBlock::new);
 }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/init/ModItems.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/init/ModItems.java
@@ -1,17 +1,36 @@
 package com.github.ysbbbbbb.kaleidoscopedoll.init;
 
 import com.github.ysbbbbbb.kaleidoscopedoll.KaleidoscopeDoll;
+import com.github.ysbbbbbb.kaleidoscopedoll.block.IModBlock;
+import com.github.ysbbbbbb.kaleidoscopedoll.item.ModBlockItem;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
+
+import java.util.Objects;
 
 public final class ModItems {
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(KaleidoscopeDoll.MOD_ID);
 
     public static DeferredItem<Item> DOLL_ICON = ITEMS.registerSimpleItem("doll_icon");
-    public static DeferredItem<BlockItem> DOLL_MACHINE = ITEMS.registerSimpleBlockItem(ModBlocks.DOLL_MACHINE);
-    public static DeferredItem<BlockItem> PURPLE_DOLL_GIFT_BOX = ITEMS.registerSimpleBlockItem(ModBlocks.PURPLE_DOLL_GIFT_BOX);
-    public static DeferredItem<BlockItem> GREEN_DOLL_GIFT_BOX = ITEMS.registerSimpleBlockItem(ModBlocks.GREEN_DOLL_GIFT_BOX);
-    public static DeferredItem<BlockItem> YELLOW_DOLL_GIFT_BOX = ITEMS.registerSimpleBlockItem(ModBlocks.YELLOW_DOLL_GIFT_BOX);
+    public static DeferredItem<BlockItem> DOLL_MACHINE = ModItems.registerModBlockItem(ModBlocks.DOLL_MACHINE);
+    public static DeferredItem<BlockItem> PURPLE_DOLL_GIFT_BOX = ModItems.registerModBlockItem(ModBlocks.PURPLE_DOLL_GIFT_BOX);
+    public static DeferredItem<BlockItem> GREEN_DOLL_GIFT_BOX = ModItems.registerModBlockItem(ModBlocks.GREEN_DOLL_GIFT_BOX);
+    public static DeferredItem<BlockItem> YELLOW_DOLL_GIFT_BOX = ModItems.registerModBlockItem(ModBlocks.YELLOW_DOLL_GIFT_BOX);
+
+    public static <T extends Block & IModBlock> DeferredItem<BlockItem> registerModBlockItem(DeferredHolder<Block, T> block) {
+        return ModItems.ITEMS.register(
+            Objects.requireNonNull(block.getKey()).location().getPath(),
+            (key) -> new ModBlockItem<>(
+                block.value(), new Item.Properties()
+                .setId(ResourceKey.create(Registries.ITEM, key))
+                .useBlockDescriptionPrefix()
+            )
+        );
+    }
 }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/init/package-info.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/init/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.github.ysbbbbbb.kaleidoscopedoll.init;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/item/ModBlockItem.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/item/ModBlockItem.java
@@ -1,8 +1,7 @@
 package com.github.ysbbbbbb.kaleidoscopedoll.item;
 
-import net.minecraft.ChatFormatting;
+import com.github.ysbbbbbb.kaleidoscopedoll.block.IModBlock;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -11,22 +10,12 @@ import net.minecraft.world.level.block.Block;
 
 import java.util.function.Consumer;
 
-public class DollItem extends BlockItem {
-    private final String langKey;
+public class ModBlockItem<T extends Block & IModBlock> extends BlockItem {
+    private final T block;
 
-    public DollItem(Block block, Properties properties, String langKey) {
+    public ModBlockItem(T block, Properties properties) {
         super(block, properties);
-        this.langKey = "tooltip.kaleidoscope_doll.doll." + langKey;
-    }
-
-    @Override
-    public EquipmentSlot getEquipmentSlot(ItemStack stack) {
-        return EquipmentSlot.HEAD;
-    }
-
-    @Override
-    public Component getName(ItemStack stack) {
-        return Component.translatable("block.kaleidoscope_doll.doll");
+        this.block = block;
     }
 
     @Override
@@ -38,6 +27,6 @@ public class DollItem extends BlockItem {
         Consumer<Component> tooltipAdder,
         TooltipFlag flag
     ) {
-        tooltipAdder.accept(Component.translatable(this.langKey).withStyle(ChatFormatting.DARK_GRAY));
+        this.block.appendHoverText(tooltipAdder);
     }
 }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/item/package-info.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/item/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.github.ysbbbbbb.kaleidoscopedoll.item;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/package-info.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopedoll/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.github.ysbbbbbb.kaleidoscopedoll;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
- 更新 ModDevGradle 版本至 2.0.107
- 创建 IModBlock 接口以支持方块物品 Tooltip
- 为 DollGiftBoxBlock 和 DollMachineBlock 实现 IModBlock 接口
- 创建 ModBlockItem 类以支持新接口
- 更新 ModBlocks 和 ModItems 类中的注册逻辑
- 在 build.gradle 中添加 JVM 参数以支持 JetBrains Runtime 特性